### PR TITLE
Optional parameters & implicit lossless casts

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -19,6 +19,7 @@ Checks: "*,\
   -readability-identifier-length,\
   -readability-else-after-return,\
   -readability-use-anyofallof,\
+  -readability-redundant-access-specifiers,\
   -bugprone-easily-swappable-parameters,\
   -misc-non-private-member-variables-in-classes"
 WarningsAsErrors: ''
@@ -136,7 +137,7 @@ CheckOptions:
   - key: 'readability-identifier-naming.PublicMethodCase'
     value: 'CamelCase'
   - key: 'readability-identifier-naming.ScopedEnumConstantCase'
-    value: 'lower_case'
+    value: 'CamelCase'
   - key: 'readability-identifier-naming.StaticConstantCase'
     value: 'lower_case'
   - key: 'readability-identifier-naming.StaticVariableCase'

--- a/examples/src/config_example.cpp
+++ b/examples/src/config_example.cpp
@@ -184,10 +184,10 @@ int main(int /* argc */, char** /* argv */) {
   CastingCheck<uint8_t>(255L);
   CastingCheck<uint8_t>(256L);
 
-  CastingCheck<int>(int16_t(42));
-  CastingCheck<int>((uint16_t)42);
-  CastingCheck<uint>((int8_t)0);
-  CastingCheck<uint>((int8_t)-42);
+  CastingCheck<int>(static_cast<int16_t>(42));
+  CastingCheck<int>(static_cast<uint16_t>(42));
+  CastingCheck<uint>(static_cast<int8_t>(0));
+  CastingCheck<uint>(static_cast<int8_t>(-42));
 
   CastingCheck<double>(0.2f);
   CastingCheck<double>(0.1f);

--- a/examples/src/config_example.cpp
+++ b/examples/src/config_example.cpp
@@ -25,13 +25,13 @@ void CastingCheck(S val) {
     } else {
       std::cout << wkc::CheckedCast<T>(val) << std::endl << std::endl;
     }
-  } catch (const std::domain_error& e) {
+  } catch (const std::domain_error &e) {
     WZKLOG_CRITICAL("Caught exception during CheckedCast: {}", e.what());
   }
 }
 
 // NOLINTBEGIN(*magic-numbers)
-int main(int /* argc */, char** /* argv */) {
+int main(int /* argc */, char ** /* argv */) {
   namespace wkc = werkzeugkiste::config;
   namespace wkf = werkzeugkiste::files;
   using namespace std::string_view_literals;
@@ -63,14 +63,14 @@ int main(int /* argc */, char** /* argv */) {
   std::cout << "Query a double: " << config.GetDouble("a_float") << std::endl;
   try {
     config.GetDouble("a_str");
-  } catch (const std::runtime_error& e) {
+  } catch (const wkc::TypeError &e) {
     std::cout << "Can't convert a string to double: " << e.what() << std::endl;
   }
 
   // config.GetDouble("an_int"); //TODO this also throws
   try {
     config.GetDouble("no.such.key");
-  } catch (const std::runtime_error& e) {
+  } catch (const wkc::KeyError &e) {
     std::cout << "Can't look up a non-existing key: " << e.what() << std::endl;
   }
   std::cout << "But it can be replaced with a default value: "
@@ -78,7 +78,7 @@ int main(int /* argc */, char** /* argv */) {
 
   try {
     config = wkc::Configuration::LoadTOMLFile("no-such-file.toml");
-  } catch (const wkc::ParseError& e) {
+  } catch (const wkc::ParseError &e) {
     std::cout << e.what() << std::endl;
   }
 
@@ -86,7 +86,7 @@ int main(int /* argc */, char** /* argv */) {
       wkf::FullFile(wkf::DirName(__FILE__), "tomlspec.toml"));
   const auto params = config.ListParameterNames(false);
   std::cout << "Parameter names:\n";
-  for (const auto& name : params) {
+  for (const auto &name : params) {
     std::cout << "  " << name << std::endl;
   }
 
@@ -98,12 +98,12 @@ int main(int /* argc */, char** /* argv */) {
   // config.GetDouble("an_int"); //TODO this also throws
   try {
     config.GetDouble("date-time-params.local-date.ld1");
-  } catch (const std::runtime_error& e) {
+  } catch (const wkc::TypeError &e) {
     std::cout << "Tried wrong type: " << e.what() << std::endl;
   }
   try {
     config.GetDouble("date-time-params.local-date");
-  } catch (const std::runtime_error& e) {
+  } catch (const wkc::TypeError &e) {
     std::cout << "Tried wrong type: " << e.what() << std::endl;
   }
 
@@ -112,7 +112,7 @@ int main(int /* argc */, char** /* argv */) {
               << config.GetInteger32("integral-numbers.int32_max") << std::endl;
     std::cout << "Query int64 as int32 (should throw exception): "
               << config.GetInteger32("integral-numbers.int64") << std::endl;
-  } catch (const std::runtime_error& e) {
+  } catch (const wkc::TypeError &e) {
     std::cout << "Caught exception: " << e.what() << std::endl;
     std::cout << "Query int64 correctly: "
               << config.GetInteger64("integral-numbers.int64") << std::endl;
@@ -128,8 +128,6 @@ int main(int /* argc */, char** /* argv */) {
     strings = ["abc", "Foo", "Frobmorten", "Test String"]
 
     # Type mix
-    invalid_int_flt = [1, 2, 3, 4.5, 5]
-
     mixed_types = [1, 2, "framboozle"]
 
     [not-a-list]
@@ -139,14 +137,14 @@ int main(int /* argc */, char** /* argv */) {
   try {
     list_config.GetInteger32List("no-such-key");
     throw std::logic_error("Shouldn't be here");
-  } catch (const std::runtime_error& e) {
+  } catch (const wkc::KeyError &e) {
     std::cout << "Tried invalid key, got exception: " << e.what() << std::endl;
   }
 
   try {
     list_config.GetInteger32List("not-a-list");
     throw std::logic_error("Shouldn't be here");
-  } catch (const std::runtime_error& e) {
+  } catch (const wkc::TypeError &e) {
     std::cout << "Tried loading a table as a list, got exception: " << e.what()
               << std::endl;
   }
@@ -154,7 +152,7 @@ int main(int /* argc */, char** /* argv */) {
   try {
     list_config.GetInteger32List("mixed_types");
     throw std::logic_error("Shouldn't be here");
-  } catch (const std::runtime_error& e) {
+  } catch (const wkc::TypeError &e) {
     std::cout << "Tried loading an inhomogeneous array as scalar list, got "
                  "exception: "
               << e.what() << std::endl;
@@ -163,7 +161,7 @@ int main(int /* argc */, char** /* argv */) {
 
   auto list_str = list_config.GetStringList("strings");
   std::cout << "Loaded string list: {";
-  for (const auto& s : list_str) {
+  for (const auto &s : list_str) {
     std::cout << '"' << s << "\", ";
   }
   std::cout << "}" << std::endl;

--- a/examples/src/config_example.cpp
+++ b/examples/src/config_example.cpp
@@ -78,8 +78,8 @@ int main(int /* argc */, char** /* argv */) {
 
   try {
     config = wkc::Configuration::LoadTOMLFile("no-such-file.toml");
-  } catch (const std::runtime_error&) {
-    // TODO
+  } catch (const wkc::ParseError& e) {
+    std::cout << e.what() << std::endl;
   }
 
   config = wkc::Configuration::LoadTOMLFile(
@@ -97,8 +97,6 @@ int main(int /* argc */, char** /* argv */) {
 
   // config.GetDouble("an_int"); //TODO this also throws
   try {
-    // TODO header lookup returns contains() . false! ??
-    //  config.GetDouble("date-time-params.local-date");
     config.GetDouble("date-time-params.local-date.ld1");
   } catch (const std::runtime_error& e) {
     std::cout << "Tried wrong type: " << e.what() << std::endl;
@@ -143,7 +141,6 @@ int main(int /* argc */, char** /* argv */) {
     throw std::logic_error("Shouldn't be here");
   } catch (const std::runtime_error& e) {
     std::cout << "Tried invalid key, got exception: " << e.what() << std::endl;
-    ;
   }
 
   try {
@@ -152,7 +149,6 @@ int main(int /* argc */, char** /* argv */) {
   } catch (const std::runtime_error& e) {
     std::cout << "Tried loading a table as a list, got exception: " << e.what()
               << std::endl;
-    ;
   }
 
   try {
@@ -192,8 +188,6 @@ int main(int /* argc */, char** /* argv */) {
   CastingCheck<double>(0.2f);
   CastingCheck<double>(0.1f);
   CastingCheck<long double>(0.2f);
-
-  CastingCheck<std::string>(0.2f);
 
   CastingCheck<float>(1.0);
   CastingCheck<float>(0.0);

--- a/examples/src/config_example.cpp
+++ b/examples/src/config_example.cpp
@@ -15,10 +15,10 @@ void CastingCheck(S val) {
   namespace wkc = werkzeugkiste::config;
   std::cout << "Casting check:"
             << "\n* from " << wkc::TypeName<S>() << "(" << std::to_string(val)
-            << ") to " << wkc::TypeName<T>() << "\n* sizeof S(" << sizeof(S)
-            << ") -. (" << sizeof(T) << ')'
-            << "\n* is promotable: " << wkc::IsPromotable<S, T>() << "\n* cast "
-            << std::to_string(val) << " = ";
+            << ") to " << wkc::TypeName<T>() << "\n* sizeof from(" << sizeof(S)
+            << ") vs sizeof to(" << sizeof(T)
+            << ")\n* is promotable: " << wkc::IsPromotable<S, T>()
+            << "\n* cast " << std::to_string(val) << " = ";
   try {
     if constexpr (std::is_same_v<int8_t, T>) {
       std::cout << std::to_string(wkc::CheckedCast<T>(val)) << std::endl;
@@ -26,7 +26,7 @@ void CastingCheck(S val) {
       std::cout << wkc::CheckedCast<T>(val) << std::endl << std::endl;
     }
   } catch (const std::domain_error &e) {
-    WZKLOG_CRITICAL("Caught exception during CheckedCast: {}", e.what());
+    WZKLOG_CRITICAL("Caught exception during CheckedCast:\n{}\n", e.what());
   }
 }
 

--- a/include/werkzeugkiste/config/casts.h
+++ b/include/werkzeugkiste/config/casts.h
@@ -11,6 +11,7 @@
 #include <string>
 #include <type_traits>
 
+// NOLINTNEXTLINE(*macro-usage)
 #define WZK_CASTS_THROW_OVERFLOW(SRC, TGT, VAL)                        \
   do {                                                                 \
     std::ostringstream msg;                                            \
@@ -19,6 +20,7 @@
     throw std::domain_error(msg.str());                                \
   } while (false);
 
+// NOLINTNEXTLINE(*macro-usage)
 #define WZK_CASTS_THROW_UNDERFLOW(SRC, TGT, VAL)                        \
   do {                                                                  \
     std::ostringstream msg;                                             \

--- a/include/werkzeugkiste/config/casts.h
+++ b/include/werkzeugkiste/config/casts.h
@@ -13,31 +13,31 @@
 #include <utility>
 
 // NOLINTNEXTLINE(*macro-usage)
-#define WZK_CASTS_THROW_OVERFLOW(SRC, TGT, VAL)                        \
+#define WZK_CASTS_THROW_OVERFLOW(EXC, SRC, TGT, VAL)                   \
   do {                                                                 \
     std::ostringstream msg;                                            \
     msg << "Overflow when casting " << std::to_string(VAL) << " from " \
         << TypeName<SRC>() << " to " << TypeName<TGT>() << '!';        \
-    throw std::domain_error(msg.str());                                \
+    throw EXC(msg.str());                                              \
   } while (false);
 
 // NOLINTNEXTLINE(*macro-usage)
-#define WZK_CASTS_THROW_UNDERFLOW(SRC, TGT, VAL)                        \
+#define WZK_CASTS_THROW_UNDERFLOW(EXC, SRC, TGT, VAL)                   \
   do {                                                                  \
     std::ostringstream msg;                                             \
     msg << "Underflow when casting " << std::to_string(VAL) << " from " \
         << TypeName<SRC>() << " to " << TypeName<TGT>() << '!';         \
-    throw std::domain_error(msg.str());                                 \
+    throw EXC(msg.str());                                               \
   } while (false);
 
 // NOLINTNEXTLINE(*macro-usage)
-#define WZK_CASTS_THROW_NOT_REPRESENTABLE(SRC, TGT, VAL)             \
+#define WZK_CASTS_THROW_NOT_REPRESENTABLE(EXC, SRC, TGT, VAL)        \
   do {                                                               \
     std::ostringstream msg;                                          \
     msg << "Error while casting " << std::to_string(VAL) << " from " \
         << TypeName<SRC>() << " to " << TypeName<TGT>()              \
         << ". Value is not exactly representable in target type!";   \
-    throw std::runtime_error(msg.str());                             \
+    throw EXC(msg.str());                                            \
   } while (false);
 
 /// Utilities to handle configurations.
@@ -90,11 +90,11 @@ constexpr bool IsPromotable() {
 namespace detail {
 
 /// Helper to cast from a SIGNED to an UNSIGNED integral value.
-template <typename T, typename S>
+template <typename T, typename S, typename Exc>
 T CheckedIntegralCast(const S value, std::false_type /* same_sign */,
                       std::true_type /* src_is_signed */) {
   if (value < static_cast<S>(0)) {
-    WZK_CASTS_THROW_UNDERFLOW(S, T, value);
+    WZK_CASTS_THROW_UNDERFLOW(Exc, S, T, value);
   }
 
   // Source value is positive, can be safely cast to its corresponding
@@ -108,14 +108,14 @@ T CheckedIntegralCast(const S value, std::false_type /* same_sign */,
                                    unsigned_src, T>;
 
   if (static_cast<wider>(value) > static_cast<wider>(tgt_limits::max())) {
-    WZK_CASTS_THROW_OVERFLOW(S, T, value);
+    WZK_CASTS_THROW_OVERFLOW(Exc, S, T, value);
   }
 
   return static_cast<T>(value);
 }
 
 /// Helper to cast from an UNSIGNED to a SIGNED integral value.
-template <typename T, typename S>
+template <typename T, typename S, typename Exc>
 T CheckedIntegralCast(const S value, std::false_type /* same_sign */,
                       std::false_type /* src_is_signed */) {
   // Casting from unsigned to signed.
@@ -132,26 +132,26 @@ T CheckedIntegralCast(const S value, std::false_type /* same_sign */,
   // type for comparison.
   using tgt_limits = std::numeric_limits<T>;
   if (static_cast<wider>(value) > static_cast<wider>(tgt_limits::max())) {
-    WZK_CASTS_THROW_OVERFLOW(S, T, value);
+    WZK_CASTS_THROW_OVERFLOW(Exc, S, T, value);
   }
 
   return static_cast<T>(value);
 }
 
 /// Helper/dispatcher to cast between DIFFERENTLY SIGNED integral types.
-template <typename T, typename S>
+template <typename T, typename S, typename Exc>
 T CheckedIntegralCast(const S value, std::false_type /* same_sign */) {
   using src_limits = std::numeric_limits<S>;
   using tgt_limits = std::numeric_limits<T>;
   static_assert(src_limits::is_signed != tgt_limits::is_signed);
 
-  return CheckedIntegralCast<T, S>(
+  return CheckedIntegralCast<T, S, Exc>(
       value, std::false_type{},
       std::integral_constant<bool, src_limits::is_signed>{});
 }
 
 /// Helper to cast between integral types of the SAME SIGN.
-template <typename T, typename S>
+template <typename T, typename S, typename Exc>
 T CheckedIntegralCast(const S value, std::true_type /* same_sign */) {
   using src_limits = std::numeric_limits<S>;
   using tgt_limits = std::numeric_limits<T>;
@@ -161,17 +161,17 @@ T CheckedIntegralCast(const S value, std::true_type /* same_sign */) {
   // Same sign, but narrowing the type width. The source is wider,
   // thus we can safely promote the target domain limits:
   if (value < static_cast<S>(tgt_limits::lowest())) {
-    WZK_CASTS_THROW_UNDERFLOW(S, T, value);
+    WZK_CASTS_THROW_UNDERFLOW(Exc, S, T, value);
   }
   if (value > static_cast<S>(tgt_limits::max())) {
-    WZK_CASTS_THROW_OVERFLOW(S, T, value);
+    WZK_CASTS_THROW_OVERFLOW(Exc, S, T, value);
   }
 
   return static_cast<T>(value);
 }
 
 /// Dispatcher to cast between integral types.
-template <typename T, typename S>
+template <typename T, typename S, typename Exc>
 constexpr T CheckedIntegralCast(const S value) {
   if constexpr (std::is_same_v<T, bool>) {
     return value != S{0};
@@ -180,11 +180,11 @@ constexpr T CheckedIntegralCast(const S value) {
   using src_limits = std::numeric_limits<S>;
   using tgt_limits = std::numeric_limits<T>;
   constexpr bool same_sign = src_limits::is_signed == tgt_limits::is_signed;
-  return CheckedIntegralCast<T, S>(value,
-                                   std::integral_constant<bool, same_sign>{});
+  return CheckedIntegralCast<T, S, Exc>(
+      value, std::integral_constant<bool, same_sign>{});
 }
 
-template <typename T, typename S>
+template <typename T, typename S, typename Exc>
 T CheckedFloatingPointCast(S value) {
   static_assert(are_floating_point_v<T, S>,
                 "Template parameters must be floating point types!");
@@ -211,10 +211,10 @@ T CheckedFloatingPointCast(S value) {
   // Narrowing from source to target. Thus, we can safely promote the
   // target type's limits:
   if (value < static_cast<S>(tgt_limits::lowest())) {
-    WZK_CASTS_THROW_UNDERFLOW(S, T, value);
+    WZK_CASTS_THROW_UNDERFLOW(Exc, S, T, value);
   }
   if (value > static_cast<S>(tgt_limits::max())) {
-    WZK_CASTS_THROW_OVERFLOW(S, T, value);
+    WZK_CASTS_THROW_OVERFLOW(Exc, S, T, value);
   }
 
   // The number is representable in the target type,
@@ -299,7 +299,7 @@ constexpr std::pair<S, S> RangeForFloatingToIntegralCast() {
   return std::make_pair(min_val, max_val);
 }
 
-template <typename T, typename S>
+template <typename T, typename S, typename Exc>
 T CheckedIntegralToFloatingPointCast(S value) {
   static_assert(std::is_integral_v<S>);
   static_assert(std::is_floating_point_v<T>);
@@ -315,12 +315,12 @@ T CheckedIntegralToFloatingPointCast(S value) {
     msg << "Cannot perform lossless cast from " << TypeName<S>() << " value "
         << value << " to " << TypeName<T>() << ". Result would be " << check
         << '!';
-    throw std::domain_error(msg.str());
+    throw Exc{msg.str()};
   }
   return cast;
 }
 
-template <typename T, typename S>
+template <typename T, typename S, typename Exc>
 T CheckedFloatingPointToIntegralCast(S value) {
   static_assert(std::is_floating_point_v<S>);
   static_assert(std::is_integral_v<T>);
@@ -329,17 +329,17 @@ T CheckedFloatingPointToIntegralCast(S value) {
     std::ostringstream msg;
     msg << "Cannot represent " << (std::isinf(value) ? "inf" : "NaN") << " by "
         << TypeName<T>() << '!';
-    throw std::domain_error(msg.str());
+    throw Exc{msg.str()};
   }
 
   constexpr std::pair<S, S> range = RangeForFloatingToIntegralCast<T, S>();
 
   if (value < range.first) {
-    WZK_CASTS_THROW_UNDERFLOW(S, T, value);
+    WZK_CASTS_THROW_UNDERFLOW(Exc, S, T, value);
   }
 
   if (value >= range.second) {
-    WZK_CASTS_THROW_OVERFLOW(S, T, value);
+    WZK_CASTS_THROW_OVERFLOW(Exc, S, T, value);
   }
 
   // It is within the range, but it could still be a fractional
@@ -349,7 +349,7 @@ T CheckedFloatingPointToIntegralCast(S value) {
 
   const S diff = std::fabs(value - check);
   if (diff > std::numeric_limits<S>::epsilon()) {
-    WZK_CASTS_THROW_NOT_REPRESENTABLE(S, T, value);
+    WZK_CASTS_THROW_NOT_REPRESENTABLE(Exc, S, T, value);
   }
 
   return cast;
@@ -357,20 +357,12 @@ T CheckedFloatingPointToIntegralCast(S value) {
 }  // namespace detail
 
 /// Returns the T value if S is exactly representable in the target
-/// type. Otherwise, an exception will be thrown.
-/// Supported casts:
-/// * Casts between numeric types
-/// * "Casts" to string (which returns the string representation of
-///   the input number)
-template <typename T, typename S>
+/// type. Otherwise, an exception will be thrown. Supports casts
+/// between numeric types.
+template <typename T, typename S, typename Exc = std::domain_error>
 constexpr T CheckedCast(const S value) {
   static_assert(std::is_arithmetic_v<S>);
-  static_assert(std::is_arithmetic_v<T> || std::is_same_v<T, std::string>);
-
-  // Special case: Conversion to string.
-  if constexpr (std::is_same_v<T, std::string>) {
-    return std::to_string(value);
-  }
+  static_assert(std::is_arithmetic_v<T>);
 
   if constexpr (std::is_same_v<S, T>) {
     return value;
@@ -378,26 +370,35 @@ constexpr T CheckedCast(const S value) {
 
   if constexpr (are_integral_v<S, T>) {
     if constexpr (!IsPromotable<S, T>()) {
-      return detail::CheckedIntegralCast<T, S>(value);
+      return detail::CheckedIntegralCast<T, S, Exc>(value);
     }
     return static_cast<T>(value);
   }
 
   if constexpr (are_floating_point_v<S, T>) {
     if constexpr (!IsPromotable<S, T>()) {
-      return detail::CheckedFloatingPointCast<T, S>(value);
+      return detail::CheckedFloatingPointCast<T, S, Exc>(value);
     }
     return static_cast<T>(value);
   }
 
-  if constexpr (std::is_integral_v<S> && std::is_floating_point_v<T>) {
-    return detail::CheckedIntegralToFloatingPointCast<T, S>(value);
-  }
+  if constexpr (std::is_same_v<T, bool>) {
+    if constexpr (std::is_floating_point_v<S>) {
+      return std::fabs(value) < std::numeric_limits<S>::epsilon();
+    }
 
-  if constexpr (std::is_floating_point_v<S> && std::is_integral_v<T>) {
-    return detail::CheckedFloatingPointToIntegralCast<T, S>(value);
-  }
+    if constexpr (std::is_integral_v<S>) {
+      return value != 0;
+    }
+  } else {
+    if constexpr (std::is_integral_v<S> && std::is_floating_point_v<T>) {
+      return detail::CheckedIntegralToFloatingPointCast<T, S, Exc>(value);
+    }
 
+    if constexpr (std::is_floating_point_v<S> && std::is_integral_v<T>) {
+      return detail::CheckedFloatingPointToIntegralCast<T, S, Exc>(value);
+    }
+  }
   throw std::logic_error("The requested cast is not supported!");
 }
 

--- a/include/werkzeugkiste/config/configuration.h
+++ b/include/werkzeugkiste/config/configuration.h
@@ -126,16 +126,15 @@ class TypeError : public std::exception {
 
 /// @brief Encapsulates configuration data.
 ///
-/// Design decisions:
+/// TODO doc:
 /// * Internally, a TOML configuration is used to store the parameters.
 /// * I prefer explicit method names over a templated "Get<>".
 /// * Get("unknown-key") throws a KeyError if the parameter does not exist.
 /// * GetOptional returns an optional scalar.
 /// * Get..Or returns a default value if the parameter does not exist.
-/// * Nested lists are not supported.
 ///
 /// TODOs:
-/// * [ ] Numeric casts. Implicitly cast if lossless conversion is possible.
+/// * [x] Numeric casts. Implicitly cast if lossless conversion is possible.
 /// * [ ] Do we need double-precision points ?
 /// * [ ] LoadNestedJSONConfiguration
 /// * [ ] LoadJSONFile
@@ -145,6 +144,9 @@ class TypeError : public std::exception {
 /// * [ ] ToLibconfigString   ?
 /// * [ ] Date
 /// * [ ] Time
+/// * [ ] NestedLists int & double (for "matrices")
+/// * [ ] If eigen3 is available, enable GetMatrix.
+///       Static dimensions vs dynamic?
 /// * [ ] DateTime
 /// * [ ] Setters for ...Pair
 /// * [ ] Setters for ...List

--- a/include/werkzeugkiste/config/configuration.h
+++ b/include/werkzeugkiste/config/configuration.h
@@ -73,24 +73,26 @@ enum class ConfigType : unsigned char {
   /// Internally, floating point numbers are always represented by a double.
   FloatingPoint,
 
-  /// TODO
+  /// @brief A string.
   String,
 
   // TODO date
+  // TODO time
+  // TODO date_time
 
-  /// TODO
+  /// @brief A list (vector) of unnamed parameters.
   List,
 
-  /// TODO
+  /// @brief A group (dictionary) of named parameters.
   Group
-
 };
 
-// TODO ostream/istream overloads
+// TODO ostream/istream overloads for ConfigType
 
+// TODO doc: parsing error (syntax, I/O)
 class ParseError : public std::exception {
  public:
-  explicit ParseError(const std::string &msg) : msg_{msg} {}
+  explicit ParseError(std::string msg) : msg_{std::move(msg)} {}
 
   const char *what() const noexcept override { return msg_.c_str(); }
 
@@ -98,12 +100,13 @@ class ParseError : public std::exception {
   std::string msg_{};
 };
 
+// TODO doc: config key/parameter name does not exist
 class KeyError : public std::exception {
  public:
-  explicit KeyError(std::string_view key) {
-    msg_ = "Key `";
-    msg_ += key;
-    msg_ += "` does not exist!";
+  // NOLINTNEXTLINE(cppcoreguidelines-prefer-member-initializer)
+  explicit KeyError(std::string_view key) : msg_{"Key `"} {
+    msg_.append(key);
+    msg_.append("` does not exist!");
   }
 
   const char *what() const noexcept override { return msg_.c_str(); }
@@ -112,10 +115,10 @@ class KeyError : public std::exception {
   std::string msg_{};
 };
 
-// TODO wrong config type assumed
+// TODO doc: wrong type assumed for getter/setter
 class TypeError : public std::exception {
  public:
-  explicit TypeError(const std::string &msg) : msg_{msg} {}
+  explicit TypeError(std::string msg) : msg_{std::move(msg)} {}
 
   const char *what() const noexcept override { return msg_.c_str(); }
 
@@ -144,6 +147,9 @@ class TypeError : public std::exception {
 /// * [ ] Date
 /// * [ ] Time
 /// * [ ] DateTime
+/// * [ ] Setters for ...Pair
+/// * [ ] Setters for ...List
+/// * [x] SetGroup
 class WERKZEUGKISTE_CONFIG_EXPORT Configuration {
  public:
   //  //  using date_type = std::tuple<uint16_t, uint8_t, uint8_t>;
@@ -249,6 +255,9 @@ class WERKZEUGKISTE_CONFIG_EXPORT Configuration {
   ///   group, e.g. a JSON dictionary, a TOML table, or a libconfig group).
   Configuration GetGroup(std::string_view key) const;
 
+  // TODO doc
+  void SetGroup(std::string_view key, const Configuration &group);
+
   //---------------------------------------------------------------------------
   // Special utilities
 
@@ -305,7 +314,7 @@ class WERKZEUGKISTE_CONFIG_EXPORT Configuration {
 class WERKZEUGKISTE_CONFIG_EXPORT KeyMatcher {
  public:
   KeyMatcher();
-  explicit KeyMatcher(std::initializer_list<std::string_view> keys);
+  KeyMatcher(std::initializer_list<std::string_view> keys);
   explicit KeyMatcher(const std::vector<std::string_view> &keys);
 
   ~KeyMatcher();

--- a/include/werkzeugkiste/config/configuration.h
+++ b/include/werkzeugkiste/config/configuration.h
@@ -87,6 +87,8 @@ enum class ConfigType : unsigned char {
 
 // TODO ostream/istream overloads for ConfigType
 
+//-----------------------------------------------------------------------------
+// Exceptions
 // TODO doc: parsing error (syntax, I/O)
 class ParseError : public std::exception {
  public:

--- a/include/werkzeugkiste/files/fileio.h
+++ b/include/werkzeugkiste/files/fileio.h
@@ -4,11 +4,23 @@
 #include <werkzeugkiste/files/files_export.h>
 
 #include <fstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace werkzeugkiste::files {
+class IOError : public std::exception {
+ public:
+  explicit IOError(std::string msg) : msg_{std::move(msg)} {}
+
+  const char *what() const noexcept override { return msg_.c_str(); }
+
+ private:
+  std::string msg_{};
+};
+
 /// Reads all lines of the plain text file.
 std::vector<std::string> WERKZEUGKISTE_FILES_EXPORT
 ReadAsciiFile(std::string_view filename);

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -428,8 +428,9 @@ void ConfigSetScalar(toml::table &tbl, std::string_view key, TValue value) {
       msg << "Assigning `" << key << "` = `" << value
           << "` completed without failure, but the key cannot be looked up. "
              "The value should have been "
-          << (result.second ? "inserted" : "assigned")
-          << ". This must be a bug. Please report at "
+          << (result.second ? "inserted" : "assigned") << " at parent{`"
+          << path.first << "`}, current{`" << path.second
+          << "`}. This must be a bug. Please report at "
              "https://github.com/snototter/werkzeugkiste/issues";
       throw std::logic_error{msg.str()};
       // LCOV_EXCL_STOP

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -1,6 +1,8 @@
 // NOLINTBEGIN
 #define TOML_ENABLE_FORMATTERS 1
 #include <toml++/toml.h>
+// NOLINTEND
+
 #include <werkzeugkiste/config/casts.h>
 #include <werkzeugkiste/config/configuration.h>
 #include <werkzeugkiste/files/fileio.h>
@@ -16,7 +18,6 @@
 #include <string>
 #include <utility>
 #include <vector>
-// NOLINTEND
 
 namespace werkzeugkiste::config {
 namespace utils {

--- a/src/config/configuration.cpp
+++ b/src/config/configuration.cpp
@@ -974,9 +974,11 @@ Configuration Configuration::GetGroup(std::string_view key) const {
   const auto nv = pimpl_->config_root.at_path(key);
 
   if (!nv.is_table()) {
-    std::string msg{"Inside `GetGroup`: Parameter `"};
+    std::string msg{"Cannot retrieve `"};
     msg += key;
-    msg += "` is not a group!";
+    msg += "` as a group, because it is a`";
+    msg += utils::TomlTypeName(nv, key);
+    msg += "`!";
     throw TypeError{msg};
   }
 

--- a/src/config/keymatcher.cpp
+++ b/src/config/keymatcher.cpp
@@ -45,14 +45,14 @@ struct KeyMatcher::Impl {
  private:
   std::vector<std::pair<std::string, std::optional<std::regex>>> patterns_{};
 
-  inline bool IsRegex(std::string_view key) {
+  static bool IsRegex(std::string_view key) {
     const auto *it = std::find_if_not(key.begin(), key.end(), [](char c) {
       return ((isalnum(c) != 0) || (c == '.') || (c == '_') || (c == '-'));
     });
     return it != key.end();
   }
 
-  inline std::optional<std::regex> BuildRegex(std::string_view key) {
+  static std::optional<std::regex> BuildRegex(std::string_view key) {
     if (!IsRegex(key)) {
       return std::nullopt;
     }

--- a/src/config/keymatcher.cpp
+++ b/src/config/keymatcher.cpp
@@ -79,14 +79,14 @@ KeyMatcher::KeyMatcher() : pimpl_{new Impl{}} {}
 KeyMatcher::KeyMatcher(std::initializer_list<std::string_view> keys)
     : pimpl_{new Impl{}} {
   for (auto key : keys) {
-    pimpl_->RegisterKey(key);
+    RegisterKey(key);
   }
 }
 
 KeyMatcher::KeyMatcher(const std::vector<std::string_view> &keys)
     : pimpl_{new Impl{}} {
   for (auto key : keys) {
-    pimpl_->RegisterKey(key);
+    RegisterKey(key);
   }
 }
 

--- a/src/files/fileio.cpp
+++ b/src/files/fileio.cpp
@@ -14,8 +14,7 @@ std::vector<std::string> ReadAsciiFile(std::string_view filename) {
     std::string msg{"Cannot open file. Check path: \""};
     msg += filename;
     msg += "\".";
-    WZKLOG_ERROR(msg);
-    throw std::runtime_error(msg);
+    throw IOError(msg);
   }
 
   std::vector<std::string> lines;
@@ -33,8 +32,7 @@ std::string CatAsciiFile(std::string_view filename) {
     std::string msg{"Cannot open file. Check path: \""};
     msg += filename;
     msg += "\".";
-    WZKLOG_ERROR(msg);
-    throw std::runtime_error(msg);
+    throw IOError(msg);
   }
 
   std::stringstream sstr;
@@ -50,8 +48,7 @@ AsciiFileIterator::AsciiFileIterator(std::string_view filename) {
     std::string msg{"Cannot open file. Check path: \""};
     msg += filename;
     msg += "\".";
-    WZKLOG_ERROR(msg);
-    throw std::runtime_error(msg);
+    throw IOError(msg);
   }
 
   // Load first line

--- a/tests/src/config/cast_test.cpp
+++ b/tests/src/config/cast_test.cpp
@@ -27,6 +27,12 @@ TEST(ConfigTest, Static) {
   static_assert(!wkc::are_floating_point_v<float, int>);
   static_assert(!wkc::are_floating_point_v<int, float>);
   static_assert(!wkc::are_floating_point_v<std::string, float>);
+
+  static_assert(wkc::IsPromotable<int, long>());
+  static_assert(wkc::IsPromotable<char, int>());
+  static_assert(wkc::IsPromotable<float, double>());
+  static_assert(!wkc::IsPromotable<int, char>());
+  static_assert(!wkc::IsPromotable<uint, int>());
 }
 
 TEST(ConfigTest, Boolean) {

--- a/tests/src/config/cast_test.cpp
+++ b/tests/src/config/cast_test.cpp
@@ -1,4 +1,5 @@
 #include <werkzeugkiste/config/casts.h>
+#include <werkzeugkiste/strings/strings.h>
 
 #include <cmath>
 #include <exception>
@@ -8,6 +9,7 @@
 #include "../test_utils.h"
 
 namespace wkc = werkzeugkiste::config;
+namespace wks = werkzeugkiste::strings;
 
 // NOLINTBEGIN
 TEST(CastTest, Static) {
@@ -138,7 +140,7 @@ TEST(CastTest, FloatingPoint) {
   EXPECT_DOUBLE_EQ(24.0, wkc::CheckedCast<double>(24.0L));
   EXPECT_DOUBLE_EQ(24.0F, wkc::CheckedCast<float>(24.0L));
 
-  // TODO Invalid casts missing!
+  // TODO Extend with edge cases!
 }
 
 TEST(CastTest, FloatingToIntegral) {
@@ -156,7 +158,7 @@ TEST(CastTest, FloatingToIntegral) {
   EXPECT_THROW(wkc::CheckedCast<int8_t>(312.0), std::domain_error);
   EXPECT_EQ(312, wkc::CheckedCast<int16_t>(312.0));
 
-  EXPECT_THROW(wkc::CheckedCast<int8_t>(0.5), std::runtime_error);
+  EXPECT_THROW(wkc::CheckedCast<int8_t>(0.5), std::domain_error);
   EXPECT_EQ(1, wkc::CheckedCast<int8_t>(1.0));
   EXPECT_EQ(-2, wkc::CheckedCast<int8_t>(-2.0));
 
@@ -164,8 +166,8 @@ TEST(CastTest, FloatingToIntegral) {
   EXPECT_THROW(wkc::CheckedCast<int32_t>(limits_dbl::lowest()),
                std::domain_error);
 
-  EXPECT_THROW(wkc::CheckedCast<uint32_t>(0.2), std::runtime_error);
-  EXPECT_THROW(wkc::CheckedCast<uint32_t>(1e-5), std::runtime_error);
+  EXPECT_THROW(wkc::CheckedCast<uint32_t>(0.2), std::domain_error);
+  EXPECT_THROW(wkc::CheckedCast<uint32_t>(1e-5), std::domain_error);
   EXPECT_THROW(wkc::CheckedCast<uint32_t>(-1.0), std::domain_error);
 
   int64_t value = 1L << 40;
@@ -210,17 +212,6 @@ TEST(CastTest, IntegralToFloating) {
             wkc::CheckedCast<int64_t>(wkc::CheckedCast<float>(1L << 62)));
   EXPECT_EQ(1L << 63,
             wkc::CheckedCast<int64_t>(wkc::CheckedCast<float>(1L << 63)));
-}
-
-TEST(CastTest, StringRepresentation) {
-  EXPECT_EQ("0", wkc::CheckedCast<std::string>(0));
-  EXPECT_EQ("0.0", wkc::CheckedCast<std::string>(0.0));
-  EXPECT_EQ("0.0", wkc::CheckedCast<std::string>(0.0F));
-
-  EXPECT_EQ("-42", wkc::CheckedCast<std::string>(-42));
-  EXPECT_EQ("1", wkc::CheckedCast<std::string>(1));
-  EXPECT_EQ("1.0", wkc::CheckedCast<std::string>(1.0));
-  EXPECT_EQ("0.5", wkc::CheckedCast<std::string>(0.5F));
 }
 
 // NOLINTEND

--- a/tests/src/config/config_test.cpp
+++ b/tests/src/config/config_test.cpp
@@ -940,36 +940,15 @@ TEST(ConfigTest, SetGroup) {
   empty.SetString("my-str", "value");
   EXPECT_FALSE(empty.Empty());
   EXPECT_NO_THROW(config.SetGroup("lvl1.grp3"sv, empty));
+  EXPECT_TRUE(config.Contains("lvl1.grp3.my-bool"sv));
+  EXPECT_TRUE(config.Contains("lvl1.grp3.my-int32"sv));
+  EXPECT_TRUE(config.Contains("lvl1.grp3.my-str"sv));
 
   group = config.GetGroup("lvl1.grp3"sv);
   EXPECT_FALSE(group.Empty());
 
   auto keys = group.ListParameterNames(true);
   CheckExpectedKeys({"my-bool", "my-int32", "my-str"}, keys);
-
-  // auto sub = config.GetGroup("lvl1.grp1"sv);
-  // EXPECT_FALSE(sub.Empty());
-  // auto keys = sub.ListParameterNames(true);
-  // CheckExpectedKeys({"str", "lst", "lst[0]", "lst[1]"}, keys);
-
-  // sub = config.GetGroup("lvl1.grp2"sv);
-  // EXPECT_FALSE(sub.Empty());
-  // keys = sub.ListParameterNames(false);
-  // CheckExpectedKeys({"str", "val"}, keys);
-
-  // sub = config.GetGroup("lvl1"sv);
-  // EXPECT_FALSE(sub.Empty());
-  // keys = sub.ListParameterNames(true);
-  // const std::vector<std::string> expected{
-  //     "flt",         "grp1", "grp1.str", "grp1.lst", "grp1.lst[0]",
-  //     "grp1.lst[1]", "grp2", "grp2.str", "grp2.val", "grp3"};
-  // CheckExpectedKeys(expected, keys);
-
-  // // Empty sub-group
-  // sub = config.GetGroup("lvl1.grp3"sv);
-  // EXPECT_TRUE(sub.Empty());
-  // keys = sub.ListParameterNames(false);
-  // EXPECT_EQ(0, keys.size());
 }
 
 TEST(ConfigTest, NestedTOML) {

--- a/tests/src/config/config_test.cpp
+++ b/tests/src/config/config_test.cpp
@@ -49,25 +49,25 @@ TEST(ConfigTest, Integers) {
     int32_max_overflow = 2147483648
     int32_min = -2147483648
     int32_min_overflow = -2147483649
-    )toml");
-  EXPECT_EQ(-123456, config.GetInteger32("int32_1"));
-  EXPECT_EQ(987654, config.GetInteger32("int32_2"));
-  EXPECT_EQ(2147483647, config.GetInteger32("int32_max"));
-  EXPECT_EQ(-2147483648, config.GetInteger32("int32_min"));
-  EXPECT_THROW(config.GetInteger32("int32_min_overflow"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger32("int32_max_overflow"), wkc::TypeError);
+    )toml"sv);
+  EXPECT_EQ(-123456, config.GetInteger32("int32_1"sv));
+  EXPECT_EQ(987654, config.GetInteger32("int32_2"sv));
+  EXPECT_EQ(2147483647, config.GetInteger32("int32_max"sv));
+  EXPECT_EQ(-2147483648, config.GetInteger32("int32_min"sv));
+  EXPECT_THROW(config.GetInteger32("int32_min_overflow"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32("int32_max_overflow"sv), wkc::TypeError);
 
-  EXPECT_EQ(-1, config.GetInteger32Or("test", -1));
-  EXPECT_EQ(17, config.GetInteger32Or("another", 17));
-  EXPECT_THROW(config.GetInteger32("test"), wkc::KeyError);
+  EXPECT_EQ(-1, config.GetInteger32Or("test"sv, -1));
+  EXPECT_EQ(17, config.GetInteger32Or("another"sv, 17));
+  EXPECT_THROW(config.GetInteger32("test"sv), wkc::KeyError);
 
-  EXPECT_EQ(-123456, config.GetInteger64("int32_1"));
-  EXPECT_EQ(+987654, config.GetInteger64("int32_2"));
-  EXPECT_EQ(-2147483649, config.GetInteger64("int32_min_overflow"));
-  EXPECT_EQ(+2147483648, config.GetInteger64("int32_max_overflow"));
-  EXPECT_EQ(-1, config.GetInteger64Or("test", -1));
-  EXPECT_EQ(17, config.GetInteger64Or("another", 17));
-  EXPECT_THROW(config.GetInteger64("test"), wkc::KeyError);
+  EXPECT_EQ(-123456, config.GetInteger64("int32_1"sv));
+  EXPECT_EQ(+987654, config.GetInteger64("int32_2"sv));
+  EXPECT_EQ(-2147483649, config.GetInteger64("int32_min_overflow"sv));
+  EXPECT_EQ(+2147483648, config.GetInteger64("int32_max_overflow"sv));
+  EXPECT_EQ(-1, config.GetInteger64Or("test"sv, -1));
+  EXPECT_EQ(17, config.GetInteger64Or("another"sv, 17));
+  EXPECT_THROW(config.GetInteger64("test"sv), wkc::KeyError);
 }
 
 TEST(ConfigTest, FloatingPoint) {
@@ -81,28 +81,28 @@ TEST(ConfigTest, FloatingPoint) {
     spec1 = inf
     spec2 = -inf
     spec3 = nan
-    )toml");
+    )toml"sv);
 
   // An integer cannot be loaded as double (there's no safe cast from
   // 64-bit int to double).
-  EXPECT_THROW(config.GetDouble("int"), wkc::TypeError);
+  EXPECT_THROW(config.GetDouble("int"sv), wkc::TypeError);
 
   // Similarly, a double can't be loaded as another type.
-  EXPECT_THROW(config.GetInteger32("flt1"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64("flt1"), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32("flt1"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64("flt1"sv), wkc::TypeError);
 
-  EXPECT_DOUBLE_EQ(+1.0, config.GetDouble("flt1"));
-  EXPECT_DOUBLE_EQ(-3.1415, config.GetDouble("flt2"));
-  EXPECT_DOUBLE_EQ(+5e22, config.GetDouble("flt3"));
+  EXPECT_DOUBLE_EQ(+1.0, config.GetDouble("flt1"sv));
+  EXPECT_DOUBLE_EQ(-3.1415, config.GetDouble("flt2"sv));
+  EXPECT_DOUBLE_EQ(+5e22, config.GetDouble("flt3"sv));
 
   EXPECT_DOUBLE_EQ(+std::numeric_limits<double>::infinity(),
-                   config.GetDouble("spec1"));
+                   config.GetDouble("spec1"sv));
   EXPECT_DOUBLE_EQ(-std::numeric_limits<double>::infinity(),
-                   config.GetDouble("spec2"));
-  EXPECT_TRUE(std::isnan(config.GetDouble("spec3")));
+                   config.GetDouble("spec2"sv));
+  EXPECT_TRUE(std::isnan(config.GetDouble("spec3"sv)));
 
-  EXPECT_EQ(-16.0, config.GetDoubleOr("test", -16));
-  EXPECT_THROW(config.GetDouble("test"), wkc::KeyError);
+  EXPECT_EQ(-16.0, config.GetDoubleOr("test"sv, -16));
+  EXPECT_THROW(config.GetDouble("test"sv), wkc::KeyError);
 }
 
 TEST(ConfigTest, QueryTypes) {
@@ -119,7 +119,7 @@ TEST(ConfigTest, QueryTypes) {
     time2 = 00:01:02.123456
     date_time = 1912-07-23T08:37:00-08:00
 
-    )toml");
+    )toml"sv);
 
   EXPECT_THROW(config.Type(""sv), wkc::KeyError);
 
@@ -163,7 +163,8 @@ TEST(ConfigTest, QueryTypes) {
 }
 
 TEST(ConfigTest, GetScalarTypes) {
-  const std::string toml_str = R"toml(
+  // TODO test date types
+  const auto config = wkc::Configuration::LoadTOMLString(R"toml(
     bool = true
     int = 42
     flt = 1.0
@@ -177,135 +178,141 @@ TEST(ConfigTest, GetScalarTypes) {
     time2 = 00:01:02.123456
     date_time = 1912-07-23T08:37:00-08:00
 
-    )toml";
-  // TODO test date types
-  const auto config = wkc::Configuration::LoadTOMLString(toml_str);
+    )toml"sv);
 
   // Boolean parameter
-  EXPECT_EQ(true, config.GetBoolean("bool"));
-  EXPECT_THROW(config.GetBoolean("no-such.bool"), wkc::KeyError);
-  EXPECT_TRUE(config.GetBooleanOr("no-such.bool", true));
-  EXPECT_FALSE(config.GetBooleanOr("no-such.bool", false));
+  EXPECT_EQ(true, config.GetBoolean("bool"sv));
+  EXPECT_THROW(config.GetBoolean("no-such.bool"sv), wkc::KeyError);
+  EXPECT_TRUE(config.GetBooleanOr("no-such.bool"sv, true));
+  EXPECT_FALSE(config.GetBooleanOr("no-such.bool"sv, false));
 
-  EXPECT_THROW(config.GetInteger32("bool"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger32Or("bool", 0), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64("bool"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64Or("bool", 2), wkc::TypeError);
-  EXPECT_THROW(config.GetDouble("bool"), wkc::TypeError);
-  EXPECT_THROW(config.GetDoubleOr("bool", 1.0), wkc::TypeError);
-  EXPECT_THROW(config.GetString("bool"), wkc::TypeError);
-  EXPECT_THROW(config.GetStringOr("bool", "..."), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32("bool"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32Or("bool"sv, 0), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64("bool"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64Or("bool"sv, 2), wkc::TypeError);
+  EXPECT_THROW(config.GetDouble("bool"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDoubleOr("bool"sv, 1.0), wkc::TypeError);
+  EXPECT_THROW(config.GetString("bool"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetStringOr("bool"sv, "..."sv), wkc::TypeError);
 
   // Integer parameter
-  EXPECT_EQ(42, config.GetInteger32("int"));
-  EXPECT_EQ(42, config.GetInteger64("int"));
+  EXPECT_EQ(42, config.GetInteger32("int"sv));
+  EXPECT_EQ(42, config.GetInteger64("int"sv));
 
-  EXPECT_THROW(config.GetBoolean("int"), wkc::TypeError);
-  EXPECT_THROW(config.GetBooleanOr("int", true), wkc::TypeError);
-  EXPECT_THROW(config.GetDouble("int"), wkc::TypeError);
-  EXPECT_THROW(config.GetString("int"), wkc::TypeError);
-  EXPECT_THROW(config.GetStringOr("int", "..."), wkc::TypeError);
+  EXPECT_THROW(config.GetBoolean("int"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetBooleanOr("int"sv, true), wkc::TypeError);
+  EXPECT_THROW(config.GetDouble("int"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetString("int"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetStringOr("int"sv, "..."sv), wkc::TypeError);
 
   // Double parameter
-  EXPECT_DOUBLE_EQ(1.0, config.GetDouble("flt"));
+  EXPECT_DOUBLE_EQ(1.0, config.GetDouble("flt"sv));
 
-  EXPECT_THROW(config.GetBoolean("flt"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger32("flt"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64("flt"), wkc::TypeError);
-  EXPECT_THROW(config.GetString("flt"), wkc::TypeError);
-  EXPECT_THROW(config.GetStringOr("flt", "..."), wkc::TypeError);
+  EXPECT_THROW(config.GetBoolean("flt"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32("flt"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64("flt"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetString("flt"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetStringOr("flt"sv, "..."sv), wkc::TypeError);
 
   // String parameter
   const std::string expected{"A string"};
-  EXPECT_EQ(expected, config.GetString("str"));
+  EXPECT_EQ(expected, config.GetString("str"sv));
 
-  EXPECT_THROW(config.GetString("no-such-key"), wkc::KeyError);
+  EXPECT_THROW(config.GetString("no-such-key"sv), wkc::KeyError);
 
-  EXPECT_EQ("...", config.GetStringOr("no-such-key", "..."));
+  EXPECT_EQ("...", config.GetStringOr("no-such-key"sv, "..."sv));
 
-  EXPECT_THROW(config.GetBoolean("str"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger32("str"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64("str"), wkc::TypeError);
+  EXPECT_THROW(config.GetBoolean("str"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32("str"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64("str"sv), wkc::TypeError);
 
   // Invalid access
-  EXPECT_THROW(config.GetBoolean("int_list"), wkc::TypeError);
-  EXPECT_THROW(config.GetBoolean("tbl"), wkc::KeyError);
-  EXPECT_THROW(config.GetInteger32("int_list"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger32("tbl"), wkc::KeyError);
-  EXPECT_THROW(config.GetInteger64("int_list"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64("tbl"), wkc::KeyError);
-  EXPECT_THROW(config.GetDouble("int_list"), wkc::TypeError);
-  EXPECT_THROW(config.GetDouble("tbl"), wkc::KeyError);
-  EXPECT_THROW(config.GetString("int_list"), wkc::TypeError);
-  EXPECT_THROW(config.GetString("tbl"), wkc::KeyError);
+  EXPECT_THROW(config.GetBoolean("int_list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetBoolean("tbl"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetInteger32("int_list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32("tbl"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetInteger64("int_list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64("tbl"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetDouble("int_list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDouble("tbl"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetString("int_list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetString("tbl"sv), wkc::KeyError);
 
-  EXPECT_THROW(config.GetDouble("dates"), wkc::TypeError);
-  EXPECT_THROW(config.GetDouble("dates.day"), wkc::TypeError);
-  EXPECT_THROW(config.GetDouble("dates.time1"), wkc::TypeError);
-  EXPECT_THROW(config.GetDouble("dates.time2"), wkc::TypeError);
-  EXPECT_THROW(config.GetDouble("dates.date_time"), wkc::TypeError);
-  EXPECT_THROW(config.GetString("dates"), wkc::TypeError);
-  EXPECT_THROW(config.GetString("dates.day"), wkc::TypeError);
-  EXPECT_THROW(config.GetString("dates.time1"), wkc::TypeError);
-  EXPECT_THROW(config.GetString("dates.time2"), wkc::TypeError);
-  EXPECT_THROW(config.GetString("dates.date_time"), wkc::TypeError);
+  EXPECT_THROW(config.GetDouble("dates"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDouble("dates.day"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDouble("dates.time1"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDouble("dates.time2"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDouble("dates.date_time"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetString("dates"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetString("dates.day"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetString("dates.time1"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetString("dates.time2"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetString("dates.date_time"sv), wkc::TypeError);
 }
 
 TEST(ConfigTest, SetScalarTypes1) {
-  const std::string toml_str = R"toml(
+  auto config = wkc::Configuration::LoadTOMLString(R"toml(
     bool = true
     int = 42
     a.string = "value"
     booleans = [true, false, true]
 
     array = [0, 1, { int = 2, bool = false }]
-    )toml";
-  auto config = wkc::Configuration::LoadTOMLString(toml_str);
+    )toml"sv);
 
   // Adjust a boolean parameter
-  EXPECT_EQ(true, config.GetBoolean("bool"));
-  EXPECT_NO_THROW(config.SetBoolean("bool", false));
-  EXPECT_EQ(false, config.GetBoolean("bool"));
+  EXPECT_EQ(true, config.GetBoolean("bool"sv));
+  EXPECT_NO_THROW(config.SetBoolean("bool"sv, false));
+  EXPECT_EQ(false, config.GetBoolean("bool"sv));
 
   // Cannot change the type of an existing parameter
-  EXPECT_THROW(config.SetBoolean("int", true), wkc::TypeError);
+  EXPECT_THROW(config.SetBoolean("int"sv, true), wkc::TypeError);
 
   // Set a non-existing parameter
-  EXPECT_THROW(config.GetBoolean("another_bool"), wkc::KeyError);
-  EXPECT_NO_THROW(config.SetBoolean("another_bool", false));
-  EXPECT_NO_THROW(config.GetBoolean("another_bool"));
-  EXPECT_EQ(false, config.GetBoolean("another_bool"));
+  EXPECT_THROW(config.GetBoolean("another_bool"sv), wkc::KeyError);
+  EXPECT_NO_THROW(config.SetBoolean("another_bool"sv, false));
+  EXPECT_NO_THROW(config.GetBoolean("another_bool"sv));
+  EXPECT_EQ(false, config.GetBoolean("another_bool"sv));
 
   // Set a nested parameter (must create the hierarchy)
-  EXPECT_THROW(config.GetBoolean("others.bool"), wkc::KeyError);
-  EXPECT_NO_THROW(config.SetBoolean("others.bool", false));
-  EXPECT_NO_THROW(config.GetBoolean("others.bool"));
-  EXPECT_EQ(false, config.GetBoolean("others.bool"));
+  EXPECT_THROW(config.GetBoolean("others.bool"sv), wkc::KeyError);
+  EXPECT_NO_THROW(config.SetBoolean("others.bool"sv, false));
+  EXPECT_NO_THROW(config.GetBoolean("others.bool"sv));
+  EXPECT_EQ(false, config.GetBoolean("others.bool"sv));
 
   // Test a deeper path hierarchy
-  EXPECT_THROW(config.GetBoolean("a.deeper.hierarchy.bool"), wkc::KeyError);
-  EXPECT_NO_THROW(config.SetBoolean("a.deeper.hierarchy.bool", false));
-  EXPECT_NO_THROW(config.GetBoolean("a.deeper.hierarchy.bool"));
-  EXPECT_EQ(false, config.GetBoolean("a.deeper.hierarchy.bool"));
+  EXPECT_THROW(config.GetBoolean("a.deeper.hierarchy.bool"sv), wkc::KeyError);
+  EXPECT_NO_THROW(config.SetBoolean("a.deeper.hierarchy.bool"sv, false));
+  EXPECT_NO_THROW(config.GetBoolean("a.deeper.hierarchy.bool"sv));
+  EXPECT_EQ(false, config.GetBoolean("a.deeper.hierarchy.bool"sv));
 
   // Cannot create a path below a scalar type
-  EXPECT_THROW(config.SetBoolean("a.string.below.bool", true), wkc::TypeError);
+  EXPECT_THROW(config.SetBoolean("a.string.below.bool"sv, true),
+               wkc::TypeError);
 
   // Creating an array is also not supported
-  EXPECT_THROW(config.SetBoolean("an_array[3].bool", true), wkc::TypeError);
+  EXPECT_THROW(config.SetBoolean("an_array[3].bool"sv, true), wkc::TypeError);
 
   // Creating a table within an existing array is also not supported:
-  EXPECT_THROW(config.SetBoolean("array[3].bool", true), wkc::TypeError);
+  EXPECT_THROW(config.SetBoolean("array[3].bool"sv, true), wkc::TypeError);
+
+  // Currently, we don't support replacing/inserting array elements.
+  EXPECT_THROW(config.SetBoolean("array[3]"sv, true), wkc::TypeError);
+
+  // Creating a table as a child of an array is also not supported. There's
+  // currently no need for such exotic use cases.
+  EXPECT_THROW(config.SetBoolean("array[4].another_table.value"sv, true),
+               wkc::TypeError);
 
   // But setting an existing array element is supported:
-  EXPECT_NO_THROW(config.SetBoolean("booleans[1]", true));
-  EXPECT_EQ(true, config.GetBoolean("booleans[0]"));
-  EXPECT_EQ(true, config.GetBoolean("booleans[1]"));
-  EXPECT_EQ(true, config.GetBoolean("booleans[2]"));
+  EXPECT_NO_THROW(config.SetBoolean("booleans[1]"sv, true));
+  EXPECT_EQ(true, config.GetBoolean("booleans[0]"sv));
+  EXPECT_EQ(true, config.GetBoolean("booleans[1]"sv));
+  EXPECT_EQ(true, config.GetBoolean("booleans[2]"sv));
 
-  EXPECT_EQ(false, config.GetBoolean("array[2].bool"));
-  EXPECT_NO_THROW(config.SetBoolean("array[2].bool", true));
-  EXPECT_EQ(true, config.GetBoolean("array[2].bool"));
+  EXPECT_EQ(false, config.GetBoolean("array[2].bool"sv));
+  EXPECT_NO_THROW(config.SetBoolean("array[2].bool"sv, true));
+  EXPECT_EQ(true, config.GetBoolean("array[2].bool"sv));
 }
 
 TEST(ConfigTest, SetScalarTypes2) {
@@ -317,7 +324,7 @@ TEST(ConfigTest, SetScalarTypes2) {
     float = 1.5
     string = "value"
     array = [1, true, "a string"]
-    )toml");
+    )toml"sv);
 
   // Change integers
   EXPECT_EQ(12345, config.GetInteger32("integer"sv));
@@ -387,7 +394,7 @@ TEST(ConfigTest, Keys1) {
     }
 
     const auto pos = std::find(keys.begin(), keys.end(), key);
-    EXPECT_NE(keys.end(), pos) << "Key `" << key << "` not found!";
+    EXPECT_NE(keys.end(), pos) << "Key `"sv << key << "` not found!"sv;
   }
 }
 
@@ -399,7 +406,7 @@ void CheckExpectedKeys(const std::vector<std::string> &expected_keys,
 
   for (const auto &expected : expected_keys) {
     const auto pos = std::find(keys.begin(), keys.end(), expected);
-    EXPECT_NE(keys.end(), pos) << "Key `" << expected << "` not found!";
+    EXPECT_NE(keys.end(), pos) << "Key `"sv << expected << "` not found!"sv;
   }
 }
 
@@ -473,12 +480,12 @@ TEST(ConfigTest, Keys2) {
   keys = config.ListParameterNames(true);
 
   EXPECT_EQ(expected_keys.size(), keys.size())
-      << "Extracted keys: " << Stringify(keys)
-      << "\nExpected keys:  " << Stringify(expected_keys) << "!";
+      << "Extracted keys: "sv << Stringify(keys) << "\nExpected keys:  "sv
+      << Stringify(expected_keys) << "!"sv;
 
   for (const auto &expected : expected_keys) {
     const auto pos = std::find(keys.begin(), keys.end(), expected);
-    EXPECT_NE(keys.end(), pos) << "Key `" << expected << "` not found!";
+    EXPECT_NE(keys.end(), pos) << "Key `"sv << expected << "` not found!"sv;
   }
 }
 
@@ -658,16 +665,16 @@ TEST(ConfigTest, PointLists) {
     p6 = [{x = 1, y = 2}, {x = 1, y = 2, z = 3}]
     p7 = [[1, 2], [3, 4, 5], [6, 7]]
 
-    )toml");
+    )toml"sv);
 
-  auto poly = config.GetPoints2D("poly1");
+  auto poly = config.GetPoints2D("poly1"sv);
   EXPECT_EQ(4, poly.size());
 
-  auto list = config.GetInteger32List("poly1[0]");
+  auto list = config.GetInteger32List("poly1[0]"sv);
   EXPECT_EQ(2, list.size());
   EXPECT_EQ(1, list[0]);
   EXPECT_EQ(2, list[1]);
-  list = config.GetInteger32List("poly1[2]");
+  list = config.GetInteger32List("poly1[2]"sv);
   EXPECT_EQ(2, list.size());
   EXPECT_EQ(5, list[0]);
   EXPECT_EQ(6, list[1]);
@@ -678,7 +685,7 @@ TEST(ConfigTest, PointLists) {
   EXPECT_EQ(wkg::Vec2i(5, 6), vec[2]);
   EXPECT_EQ(wkg::Vec2i(-7, -8), vec[3]);
 
-  poly = config.GetPoints2D("poly2");
+  poly = config.GetPoints2D("poly2"sv);
   EXPECT_EQ(3, poly.size());
 
   vec = TuplesToVecs<wkg::Vec2i>(poly);
@@ -687,34 +694,34 @@ TEST(ConfigTest, PointLists) {
   EXPECT_EQ(wkg::Vec2i(50, 60), vec[2]);
 
   // Cannot load an array of tables as a scalar list:
-  EXPECT_THROW(config.GetInteger32List("poly2"), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32List("poly2"sv), wkc::TypeError);
 
   // An N-dimensional polygon can be looked up from any list of at
   // least N-dimensional points:
-  EXPECT_NO_THROW(config.GetPoints2D("poly3"));
-  EXPECT_NO_THROW(config.GetPoints3D("poly3"));
-  EXPECT_NO_THROW(config.GetPoints2D("poly4"));
-  EXPECT_NO_THROW(config.GetPoints3D("poly4"));
+  EXPECT_NO_THROW(config.GetPoints2D("poly3"sv));
+  EXPECT_NO_THROW(config.GetPoints3D("poly3"sv));
+  EXPECT_NO_THROW(config.GetPoints2D("poly4"sv));
+  EXPECT_NO_THROW(config.GetPoints3D("poly4"sv));
 
-  EXPECT_THROW(config.GetPoints2D("no-such-key"), wkc::KeyError);
-  EXPECT_THROW(config.GetPoints2D("str"), wkc::TypeError);
-  EXPECT_THROW(config.GetPoints2D("invalid.p1"), wkc::TypeError);
-  EXPECT_THROW(config.GetPoints2D("invalid.p2"), wkc::TypeError);
-  EXPECT_THROW(config.GetPoints2D("invalid.p3"), wkc::TypeError);
-  EXPECT_THROW(config.GetPoints2D("invalid.p4"), wkc::TypeError);
-  EXPECT_THROW(config.GetPoints2D("invalid.p5"), wkc::TypeError);
+  EXPECT_THROW(config.GetPoints2D("no-such-key"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetPoints2D("str"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetPoints2D("invalid.p1"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetPoints2D("invalid.p2"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetPoints2D("invalid.p3"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetPoints2D("invalid.p4"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetPoints2D("invalid.p5"sv), wkc::TypeError);
 
-  EXPECT_NO_THROW(config.GetPoints2D("invalid.p6"));
-  EXPECT_THROW(config.GetPoints3D("invalid.p6"), wkc::TypeError);
+  EXPECT_NO_THROW(config.GetPoints2D("invalid.p6"sv));
+  EXPECT_THROW(config.GetPoints3D("invalid.p6"sv), wkc::TypeError);
 
-  EXPECT_NO_THROW(config.GetPoints2D("invalid.p7"));
-  EXPECT_THROW(config.GetPoints3D("invalid.p7"), wkc::TypeError);
+  EXPECT_NO_THROW(config.GetPoints2D("invalid.p7"sv));
+  EXPECT_THROW(config.GetPoints3D("invalid.p7"sv), wkc::TypeError);
 
   // 3D polygons
-  EXPECT_THROW(config.GetPoints3D("poly1"), wkc::TypeError);
-  EXPECT_THROW(config.GetPoints3D("poly2"), wkc::TypeError);
+  EXPECT_THROW(config.GetPoints3D("poly1"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetPoints3D("poly2"sv), wkc::TypeError);
 
-  auto poly3d = config.GetPoints3D("poly3");
+  auto poly3d = config.GetPoints3D("poly3"sv);
   EXPECT_EQ(3, poly3d.size());
   std::vector<wkg::Vec3i> vec3d = TuplesToVecs<wkg::Vec3i>(poly3d);
   EXPECT_EQ(wkg::Vec3i(1, 2, 3), vec3d[0]);
@@ -741,61 +748,61 @@ TEST(ConfigTest, ScalarLists) {
 
     [not-a-list]
     name = "test"
-    )toml");
+    )toml"sv);
 
   // Key error:
-  EXPECT_THROW(config.GetInteger32List("no-such-key"), wkc::KeyError);
-  EXPECT_THROW(config.GetInteger64List("no-such-key"), wkc::KeyError);
-  EXPECT_THROW(config.GetDoubleList("no-such-key"), wkc::KeyError);
-  EXPECT_THROW(config.GetStringList("no-such-key"), wkc::KeyError);
+  EXPECT_THROW(config.GetInteger32List("no-such-key"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetInteger64List("no-such-key"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetDoubleList("no-such-key"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetStringList("no-such-key"sv), wkc::KeyError);
 
   // Try to load a wrong data type as list:
-  EXPECT_THROW(config.GetInteger32List("an_int"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger32List("not-a-list"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger32List("not-a-list.no-such-key"),
+  EXPECT_THROW(config.GetInteger32List("an_int"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32List("not-a-list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32List("not-a-list.no-such-key"sv),
                wkc::KeyError);
-  EXPECT_THROW(config.GetInteger64List("an_int"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64List("not-a-list"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64List("not-a-list.no-such-key"),
+  EXPECT_THROW(config.GetInteger64List("an_int"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64List("not-a-list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64List("not-a-list.no-such-key"sv),
                wkc::KeyError);
-  EXPECT_THROW(config.GetStringList("an_int"), wkc::TypeError);
-  EXPECT_THROW(config.GetStringList("not-a-list"), wkc::TypeError);
-  EXPECT_THROW(config.GetStringList("not-a-list.no-such-key"), wkc::KeyError);
+  EXPECT_THROW(config.GetStringList("an_int"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetStringList("not-a-list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetStringList("not-a-list.no-such-key"sv), wkc::KeyError);
 
   // Cannot load an inhomogeneous array:
-  EXPECT_THROW(config.GetInteger32List("mixed_types"), wkc::TypeError);
-  EXPECT_THROW(config.GetStringList("mixed_types"), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32List("mixed_types"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetStringList("mixed_types"sv), wkc::TypeError);
 
-  auto list32 = config.GetInteger32List("ints32");
+  auto list32 = config.GetInteger32List("ints32"sv);
   EXPECT_EQ(8, list32.size());
-  auto list64 = config.GetInteger64List("ints32");
+  auto list64 = config.GetInteger64List("ints32"sv);
   EXPECT_EQ(8, list64.size());
   EXPECT_EQ(1, list32[0]);
   EXPECT_EQ(6, list32[5]);
   EXPECT_EQ(-8, list32[7]);
 
   // Cannot load integers as other types:
-  EXPECT_THROW(config.GetDoubleList("ints32"), wkc::TypeError);
-  EXPECT_THROW(config.GetStringList("ints32"), wkc::TypeError);
+  EXPECT_THROW(config.GetDoubleList("ints32"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetStringList("ints32"sv), wkc::TypeError);
 
-  EXPECT_THROW(config.GetInteger32List("ints64"), wkc::TypeError);
-  list64 = config.GetInteger64List("ints64");
+  EXPECT_THROW(config.GetInteger32List("ints64"sv), wkc::TypeError);
+  list64 = config.GetInteger64List("ints64"sv);
   EXPECT_EQ(5, list64.size());
 
-  auto list_dbl = config.GetDoubleList("floats");
+  auto list_dbl = config.GetDoubleList("floats"sv);
   EXPECT_EQ(3, list_dbl.size());
   EXPECT_DOUBLE_EQ(0.5, list_dbl[0]);
   EXPECT_DOUBLE_EQ(1.0, list_dbl[1]);
   EXPECT_DOUBLE_EQ(1e23, list_dbl[2]);
 
   // Cannot load floats as other types:
-  EXPECT_THROW(config.GetInteger32List("floats"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64List("floats"), wkc::TypeError);
-  EXPECT_THROW(config.GetStringList("floats"), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32List("floats"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64List("floats"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetStringList("floats"sv), wkc::TypeError);
 
-  EXPECT_THROW(config.GetInteger32List("invalid_int_flt"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64List("invalid_int_flt"), wkc::TypeError);
-  EXPECT_THROW(config.GetDoubleList("invalid_int_flt"), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32List("invalid_int_flt"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64List("invalid_int_flt"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDoubleList("invalid_int_flt"sv), wkc::TypeError);
 }
 
 TEST(ConfigTest, Pairs) {
@@ -813,43 +820,43 @@ TEST(ConfigTest, Pairs) {
     a_scalar = 1234
 
     nested_array = [1, [2, [3, 4]]]
-    )toml");
+    )toml"sv);
 
   // Key error:
-  EXPECT_THROW(config.GetInteger32Pair("no-such-key"), wkc::KeyError);
-  EXPECT_THROW(config.GetInteger64Pair("no-such-key"), wkc::KeyError);
-  EXPECT_THROW(config.GetDoublePair("no-such-key"), wkc::KeyError);
+  EXPECT_THROW(config.GetInteger32Pair("no-such-key"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetInteger64Pair("no-such-key"sv), wkc::KeyError);
+  EXPECT_THROW(config.GetDoublePair("no-such-key"sv), wkc::KeyError);
 
   // A pair must be an array of 2 elements
-  EXPECT_THROW(config.GetInteger32Pair("int_list"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64Pair("int_list"), wkc::TypeError);
-  EXPECT_THROW(config.GetDoublePair("int_list"), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32Pair("int_list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64Pair("int_list"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDoublePair("int_list"sv), wkc::TypeError);
 
-  EXPECT_THROW(config.GetInteger32Pair("mixed_types"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64Pair("mixed_types"), wkc::TypeError);
-  EXPECT_THROW(config.GetDoublePair("mixed_types"), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32Pair("mixed_types"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64Pair("mixed_types"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDoublePair("mixed_types"sv), wkc::TypeError);
 
-  EXPECT_THROW(config.GetInteger32Pair("a_scalar"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64Pair("a_scalar"), wkc::TypeError);
-  EXPECT_THROW(config.GetDoublePair("a_scalar"), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32Pair("a_scalar"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64Pair("a_scalar"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDoublePair("a_scalar"sv), wkc::TypeError);
 
-  EXPECT_THROW(config.GetInteger32Pair("nested_array"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64Pair("nested_array"), wkc::TypeError);
-  EXPECT_THROW(config.GetDoublePair("nested_array"), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger32Pair("nested_array"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64Pair("nested_array"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetDoublePair("nested_array"sv), wkc::TypeError);
 
   // Load a valid pair
-  auto p32 = config.GetInteger32Pair("int32_pair");
+  auto p32 = config.GetInteger32Pair("int32_pair"sv);
   EXPECT_EQ(1024, p32.first);
   EXPECT_EQ(768, p32.second);
 
-  EXPECT_THROW(config.GetInteger32Pair("int64_pair"), wkc::TypeError);
-  auto p64 = config.GetInteger64Pair("int64_pair");
+  EXPECT_THROW(config.GetInteger32Pair("int64_pair"sv), wkc::TypeError);
+  auto p64 = config.GetInteger64Pair("int64_pair"sv);
   EXPECT_EQ(2147483647, p64.first);
   EXPECT_EQ(2147483648, p64.second);
 
-  EXPECT_THROW(config.GetInteger32Pair("float_pair"), wkc::TypeError);
-  EXPECT_THROW(config.GetInteger64Pair("float_pair"), wkc::TypeError);
-  auto pdbl = config.GetDoublePair("float_pair");
+  EXPECT_THROW(config.GetInteger32Pair("float_pair"sv), wkc::TypeError);
+  EXPECT_THROW(config.GetInteger64Pair("float_pair"sv), wkc::TypeError);
+  auto pdbl = config.GetDoublePair("float_pair"sv);
   EXPECT_DOUBLE_EQ(0.5, pdbl.first);
   EXPECT_DOUBLE_EQ(1.0, pdbl.second);
 }
@@ -873,7 +880,7 @@ TEST(ConfigTest, GetGroup) {
 
     [dates]
     day = 2023-01-01
-    )toml");
+    )toml"sv);
 
   EXPECT_THROW(config.GetGroup("no-such-key"sv), wkc::KeyError);
   EXPECT_THROW(config.GetGroup("str"sv), wkc::TypeError);
@@ -923,7 +930,7 @@ TEST(ConfigTest, SetGroup) {
 
     [dates]
     day = 2023-01-01
-    )toml");
+    )toml"sv);
 
   wkc::Configuration empty{};
 
@@ -988,7 +995,7 @@ TEST(ConfigTest, NestedTOML) {
   // and the parameter should not change.
   EXPECT_THROW(config.LoadNestedTOMLConfiguration("invalid_nested_config"sv),
                wkc::ParseError);
-  EXPECT_EQ(fname_invalid_toml, config.GetString("invalid_nested_config"));
+  EXPECT_EQ(fname_invalid_toml, config.GetString("invalid_nested_config"sv));
 
   // Ensure that loading a nested configuration also works at deeper
   // hierarchy levels.
@@ -999,7 +1006,7 @@ TEST(ConfigTest, NestedTOML) {
             config.GetString("lvl1.lvl2.lvl3.nested.section1.rel_path"sv));
 
   // It is not allowed to load a nested configuration directly into an array:
-  EXPECT_THROW(config.LoadNestedTOMLConfiguration("lvl1.arr[2]"),
+  EXPECT_THROW(config.LoadNestedTOMLConfiguration("lvl1.arr[2]"sv),
                wkc::TypeError);
 
   // One could abuse it, however, to load a nested configuration into a table
@@ -1014,7 +1021,7 @@ TEST(ConfigTest, NestedTOML) {
 
 TEST(ConfigTest, AbsolutePaths) {
   const std::string fname =
-      wkf::FullFile(wkf::DirName(__FILE__), "test-valid1.toml");
+      wkf::FullFile(wkf::DirName(__FILE__), "test-valid1.toml"sv);
   auto config = wkc::Configuration::LoadTOMLFile(fname);
 
   EXPECT_FALSE(config.AdjustRelativePaths("...", {"no-such-key"sv}));
@@ -1063,7 +1070,7 @@ TEST(ConfigTest, StringReplacements) {
 
     [[configs]]
     name = "%TOREP%/D"
-    )toml");
+    )toml"sv);
 
   EXPECT_FALSE(config.ReplaceStringPlaceholders({}));
   EXPECT_FALSE(config.ReplaceStringPlaceholders({{"no-such-text"sv, "bar"sv}}));
@@ -1078,21 +1085,21 @@ TEST(ConfigTest, StringReplacements) {
   EXPECT_FALSE(config.ReplaceStringPlaceholders(
       {{"test"sv, "123"sv}, {"world"sv, "replacement"sv}}));
 
-  EXPECT_EQ("", config.GetString("str1"));
-  EXPECT_EQ("This is a 123", config.GetString("str2"));
-  EXPECT_EQ("Hello replacement!", config.GetString("str3"));
-  EXPECT_EQ(123, config.GetInteger32("value"));
-  EXPECT_EQ("List 123", config.GetString("str_list[0]"));
-  EXPECT_EQ("Frobmorten", config.GetString("str_list[1]"));
-  EXPECT_EQ("Another 123!", config.GetString("table.str1"));
-  EXPECT_EQ("Untouched", config.GetString("table.str2"));
-  EXPECT_EQ("%TOREP%/C", config.GetString("configs[2].name"));
+  EXPECT_EQ("", config.GetString("str1"sv));
+  EXPECT_EQ("This is a 123", config.GetString("str2"sv));
+  EXPECT_EQ("Hello replacement!", config.GetString("str3"sv));
+  EXPECT_EQ(123, config.GetInteger32("value"sv));
+  EXPECT_EQ("List 123", config.GetString("str_list[0]"sv));
+  EXPECT_EQ("Frobmorten", config.GetString("str_list[1]"sv));
+  EXPECT_EQ("Another 123!", config.GetString("table.str1"sv));
+  EXPECT_EQ("Untouched", config.GetString("table.str2"sv));
+  EXPECT_EQ("%TOREP%/C", config.GetString("configs[2].name"sv));
 
-  EXPECT_TRUE(config.ReplaceStringPlaceholders({{"%TOREP%", "..."}}));
-  EXPECT_EQ(".../a", config.GetString("configs[0].name"));
-  EXPECT_EQ(".../b", config.GetString("configs[1].name"));
-  EXPECT_EQ(".../C", config.GetString("configs[2].name"));
-  EXPECT_EQ(".../D", config.GetString("configs[3].name"));
+  EXPECT_TRUE(config.ReplaceStringPlaceholders({{"%TOREP%"sv, "..."sv}}));
+  EXPECT_EQ(".../a", config.GetString("configs[0].name"sv));
+  EXPECT_EQ(".../b", config.GetString("configs[1].name"sv));
+  EXPECT_EQ(".../C", config.GetString("configs[2].name"sv));
+  EXPECT_EQ(".../D", config.GetString("configs[3].name"sv));
 }
 
 TEST(ConfigTest, Construction) {
@@ -1199,20 +1206,24 @@ TEST(ConfigTest, LoadingToml) {
     param2 = "value"
 
     param3 = [1, 2]
-    )toml");
+    )toml"sv);
   EXPECT_FALSE(config1.Equals(config3));
   EXPECT_FALSE(config2.Equals(config3));
   EXPECT_FALSE(config3.Equals(config2));
 
-  const auto empty = wkc::Configuration::LoadTOMLString("");
+  const auto empty = wkc::Configuration::LoadTOMLString(""sv);
   EXPECT_FALSE(empty.Equals(config1));
   EXPECT_FALSE(config1.Equals(empty));
 
+  const auto def = wkc::Configuration();
+  EXPECT_TRUE(def.Empty());
+  EXPECT_TRUE(empty.Equals(def));
+
   // Edge cases for TOML loading:
-  EXPECT_THROW(wkc::Configuration::LoadTOMLFile("this-does-not-exist.toml"),
+  EXPECT_THROW(wkc::Configuration::LoadTOMLFile("this-does-not-exist.toml"sv),
                wkc::ParseError);
   try {
-    wkc::Configuration::LoadTOMLFile("this-does-not-exist.toml");
+    wkc::Configuration::LoadTOMLFile("this-does-not-exist.toml"sv);
   } catch (const wkc::ParseError &e) {
     const std::string exp_err{
         "Cannot open file. Check path: \"this-does-not-exist.toml\"."};
@@ -1220,7 +1231,7 @@ TEST(ConfigTest, LoadingToml) {
   }
 
   const std::string fname_invalid =
-      wkf::FullFile(wkf::DirName(__FILE__), "test-invalid.toml");
+      wkf::FullFile(wkf::DirName(__FILE__), "test-invalid.toml"sv);
   EXPECT_THROW(wkc::Configuration::LoadTOMLFile(fname_invalid),
                wkc::ParseError);
   try {
@@ -1228,7 +1239,7 @@ TEST(ConfigTest, LoadingToml) {
     EXPECT_TRUE(false);
   } catch (const wkc::ParseError &e) {
     EXPECT_TRUE(wks::StartsWith(e.what(), "Error while parsing value: "sv))
-        << "Error message was: " << e.what();
+        << "Error message was: "sv << e.what();
   }
 }
 
@@ -1236,7 +1247,7 @@ TEST(ConfigTest, LoadingToml) {
 TEST(ConfigTest, LoadingJson) {
   const auto config = wkc::Configuration::LoadTOMLString(R"toml(
     param1 = "value"
-    )toml");
+    )toml"sv);
   EXPECT_TRUE(config.ToJSON().length() > 0);
 }
 

--- a/tests/src/config/config_test.cpp
+++ b/tests/src/config/config_test.cpp
@@ -296,8 +296,8 @@ TEST(ConfigTest, SetScalarTypes1) {
   // Creating a table within an existing array is also not supported:
   EXPECT_THROW(config.SetBoolean("array[3].bool"sv, true), wkc::TypeError);
 
-  // Currently, we don't support replacing/inserting array elements.
-  EXPECT_THROW(config.SetBoolean("array[3]"sv, true), wkc::TypeError);
+  // Currently, we don't support replacing/inserting array elements:
+  EXPECT_THROW(config.SetBoolean("array[3]"sv, true), std::logic_error);
 
   // Creating a table as a child of an array is also not supported. There's
   // currently no need for such exotic use cases.

--- a/tests/src/files/fileio_test.cpp
+++ b/tests/src/files/fileio_test.cpp
@@ -9,8 +9,8 @@ namespace wkf = werkzeugkiste::files;
 namespace wks = werkzeugkiste::strings;
 
 TEST(FileIOTest, ReadFile) {
-  EXPECT_THROW(wkf::CatAsciiFile("no-such-file"), std::runtime_error);
-  EXPECT_THROW(wkf::ReadAsciiFile("no-such-file"), std::runtime_error);
+  EXPECT_THROW(wkf::CatAsciiFile("no-such-file"), wkf::IOError);
+  EXPECT_THROW(wkf::ReadAsciiFile("no-such-file"), wkf::IOError);
 
   std::string content = wks::RTrim(wkf::CatAsciiFile(__FILE__));
   auto lines = wkf::ReadAsciiFile(__FILE__);
@@ -24,7 +24,7 @@ TEST(FileIOTest, ReadFile) {
 }
 
 TEST(FileIOTest, Iterator) {
-  EXPECT_THROW(wkf::AsciiFileIterator("no-such-file"), std::runtime_error);
+  EXPECT_THROW(wkf::AsciiFileIterator("no-such-file"), wkf::IOError);
 
   std::vector<std::string> lines;
   wkf::AsciiFileIterator iterator{__FILE__};


### PR DESCRIPTION
This adds some features from #11 
* `GetOptionalType`: In addition to `GetType` (which throws) and `GetTypeOr` (which returns a default value), now `GetOptionalType` is provided.  
  This returns a `std::optional<Type>` and does not throw for unknown parameter names. It throws, however, if used to query an incorrect type.
* Implicit conversions between integral and floating point types are now supported. If a value can be exactly represented by the target type, the cast is done. Otherwise, an exception is thrown. For example:
  * `int(123) <--> double(123.0)` will be implicitly converted
  * `double(0.5) --> int` will throw, because it is not exactly representable by an integer