### PR TITLE
bump coveralls

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,10 +64,11 @@ jobs:
       run: cmake --build build/coverage -t coverage
 
     - name: Update coveralls.io
-      uses: coverallsapp/github-action@v1.2.4
+      uses: coverallsapp/github-action@v2.0.0
       with:
         github-token: ${{ github.token }}
-        path-to-lcov: build/coverage/coverage.info
+        file: build/coverage/coverage.info
+        format: lcov
 
   sanitize:
     needs: [lint]


### PR DESCRIPTION
* simply upgrading the [coveralls action](https://github.com/coverallsapp/github-action/issues/159) breaks the ci
* official [upgrade notes](https://github.com/coverallsapp/github-action/blob/release/v2/UPGRADE.md#v1---v2)
* related [issue on the github-action](https://github.com/coverallsapp/github-action/issues/159)
* this PR additionally specifies the `format` flag for [coverage-reporter](https://github.com/coverallsapp/coverage-reporter)